### PR TITLE
Convert 'Libclang.version' to a 'Gem::Version' for version check

### DIFF
--- a/gem/lib/rb_sys/mkmf.rb
+++ b/gem/lib/rb_sys/mkmf.rb
@@ -326,7 +326,7 @@ module RbSys
     end
 
     def assert_libclang_version_valid!
-      libclang_version = Libclang.version
+      libclang_version = Gem::Version.new(Libclang.version)
 
       if libclang_version < Gem::Version.new("5.0.0")
         raise "libclang version 5.0.0 or greater is required (current #{libclang_version})"


### PR DESCRIPTION
When attempting to use the `libclang` gem in a Rust project using `rb-sys/mkmf`, the version check fails with:

```
/home/wfc/.local/share/rtx/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/rb_sys-0.9.71/lib/rb_sys/mkmf.rb:332:in `<': comparison of String with Gem::Version failed (ArgumentError)
        from /home/wfc/.local/share/rtx/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/rb_sys-0.9.71/lib/rb_sys/mkmf.rb:332:in `assert_libclang_version_valid!'
        from /home/wfc/.local/share/rtx/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/rb_sys-0.9.71/lib/rb_sys/mkmf.rb:322:in `try_load_bundled_libclang'
        from /home/wfc/.local/share/rtx/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/rb_sys-0.9.71/lib/rb_sys/mkmf.rb:62:in `create_rust_makefile'
        from ../../../../ext/fast_mmaped_file_rs/extconf.rb:4:in `<main>'
rake aborted!
```

To resolve this, convert the version string from `libclang` into a `Gem::Version`.